### PR TITLE
Update installation URI in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ This software released under the MIT License.
 
 To install directly from this repository:
 
-``pip install git+git://github.com/elliptic-shiho/primefac-fork@master``
+``pip install git+https://github.com/elliptic-shiho/primefac-fork@master``
 


### PR DESCRIPTION
Changed from `git+git` to `git+https`. Wasn't working on my kali wsl.